### PR TITLE
Export Pod labels as a timeseries

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,22 +15,18 @@ class KubernetesAPIExporter(object):
   def collect(self):
     self.gauge_cache = {}
 
-    pykube.Deployment.objects.namespace = None
     for deployment in pykube.Deployment.objects(api).all():
       labels = labels_for(deployment.obj)
       self.record_ts_for_thing(deployment.obj, labels, ["k8s", "deployment"])
 
-    pykube.Pod.objects.namespace = None
     for pod in pykube.Pod.objects(api).all():
       labels = labels_for(pod.obj)
       self.record_ts_for_thing(pod.obj, labels, ["k8s", "pod"])
 
-    pykube.ReplicationController.objects.namespace = None
     for pod in pykube.ReplicationController.objects(api).all():
       labels = labels_for(pod.obj)
       self.record_ts_for_thing(pod.obj, labels, ["k8s", "rc"])
 
-    pykube.DaemonSet.objects.namespace = None
     for pod in pykube.DaemonSet.objects(api).all():
       labels = labels_for(pod.obj)
       self.record_ts_for_thing(pod.obj, labels, ["k8s", "ds"])
@@ -69,11 +65,30 @@ class KubernetesAPIExporter(object):
       self.record_ts_for_thing(value, labels, path)
 
 
+class PodLabelExporter(object):
+
+  def __init__(self, api):
+    self.api = api
+
+  def collect(self):
+    metric = prometheus_client.core.GaugeMetricFamily("k8s_pod_labels", "Timeseries with the labels for the pod, always 1.0, for joining.")
+
+    for pod in pykube.Pod.objects(api).all():
+      unprocessed_labels = safe_lookup(pod.obj, ["metadata", "labels"], {})
+      unprocessed_labels["namespace"] = safe_lookup(pod.obj, ["metadata", "namespace"], "default")
+      unprocessed_labels["pod_name"] = safe_lookup(pod.obj, ["metadata", "name"])
+      labels = {k.replace('-', '_').replace('/', '_').replace('.', '_'): v for k, v in unprocessed_labels.items()}
+      metric.samples.append((metric.name, labels, 1.0))
+
+    yield metric
+
+
 def labels_for(obj):
   labels = collections.OrderedDict()
   labels["namespace"] = safe_lookup(obj, ["metadata", "namespace"], default="default")
   labels["name"] = safe_lookup(obj, ["metadata", "name"], default="")
   return labels
+
 
 def safe_lookup(d, ks, default=None):
   for k in ks:
@@ -88,6 +103,8 @@ def sigterm_handler(_signo, _stack_frame):
 
 
 if __name__ == "__main__":
+  logging.basicConfig(level=logging.INFO)
+
   parser =  optparse.OptionParser("""usage: %prog [options]""")
   parser.add_option("--port",
     dest="port", default=80, type="int",
@@ -97,7 +114,9 @@ if __name__ == "__main__":
   logging.info("Listening on %d", options.port)
 
   api = pykube.HTTPClient(pykube.KubeConfig.from_service_account())
+  api.config.contexts[api.config.current_context]["namespace"] = None # Hack to fetch objects from all namespaces
   prometheus_client.REGISTRY.register(KubernetesAPIExporter(api))
+  prometheus_client.REGISTRY.register(PodLabelExporter(api))
   prometheus_client.start_http_server(options.port)
 
   signal.signal(signal.SIGTERM, sigterm_handler)


### PR DESCRIPTION
Export a timeseries (of all 1.0s) with the pod labels, for joining with cAdvisor metrics:

```
# HELP k8s_pod_labels Timeseries with the labels for the pod, always 1.0, for joining.
# TYPE k8s_pod_labels gauge
k8s_pod_labels{component="kube-addon-manager",namespace="kube-system",pod_name="kube-addon-manager-minikube",version="v5.1"} 1.0
k8s_pod_labels{k8s_app="kube-dns",namespace="kube-system",pod_name="kube-dns-v20-pupzu",version="v20"} 1.0
k8s_pod_labels{app="kubernetes-dashboard",kubernetes_io_cluster_service="true",namespace="kube-system",pod_name="kubernetes-dashboard-pqdph",version="v1.4.2"} 1.0
k8s_pod_labels{name="kube-api-exporter",namespace="monitoring",pod_name="kube-api-exporter-74173974-bwjvb",pod_template_hash="74173974"} 1.0
k8s_pod_labels{name="prometheus",namespace="monitoring",pod_name="prometheus-2800755020-5ao8b",pod_template_hash="2800755020"} 1.0
```

We can then do queries like:

```
sum by (namespace, name) (
  sum(irate(container_cpu_usage_seconds_total{image!=""}[1m])) by (namespace, pod_name)
* on (namespace, pod_name) group_left(name)
  k8s_pod_labels{job="monitoring/kube-api-exporter"}
)
```

To get aggregate container CPU usage by namespace and "name", which is a custom label applied to pods to specify what "service" they are part of.

Method inspired by https://www.robustperception.io/exposing-the-software-version-to-prometheus/ and https://github.com/kubernetes/kubernetes/issues/32326.