### PR TITLE
Export image data

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,25 +84,21 @@ class PodLabelExporter(object):
 
 
 def get_pod_labels(pod):
-  unprocessed_labels = safe_lookup(pod.obj, ["metadata", "labels"], {})
-  unprocessed_labels["namespace"] = safe_lookup(pod.obj, ["metadata", "namespace"], "default")
-  unprocessed_labels["pod_name"] = safe_lookup(pod.obj, ["metadata", "name"])
+  metadata = pod.obj.get('metadata', {})
+  unprocessed_labels = metadata.get('labels', {})
+  unprocessed_labels.update({
+    'namespace': metadata.get('namespace', "default"),
+    'pod_name': metadata.get('name', "")
+  })
   return {k.replace('-', '_').replace('/', '_').replace('.', '_'): v for k, v in unprocessed_labels.items()}
 
 
 def labels_for(obj):
+  metadata = obj.get('metadata', {})
   labels = collections.OrderedDict()
-  labels["namespace"] = safe_lookup(obj, ["metadata", "namespace"], default="default")
-  labels["name"] = safe_lookup(obj, ["metadata", "name"], default="")
+  labels["namespace"] = metadata.get('namespace', "default")
+  labels["name"] = metadata.get('name', "")
   return labels
-
-
-def safe_lookup(d, ks, default=None):
-  for k in ks:
-    if k not in d:
-      return default
-    d = d[k]
-  return d
 
 
 def sigterm_handler(_signo, _stack_frame):

--- a/main.py
+++ b/main.py
@@ -50,16 +50,14 @@ class KubernetesAPIExporter(object):
 
   def record_ts_for_obj(self, obj, labels, path, gauge_cache):
     for key, value in obj.items():
-      key_path = list(path)
-      key_path.append(key)
-      self.record_ts_for_thing(value, labels, key_path, gauge_cache)
+      self.record_ts_for_thing(value, labels, path + [key], gauge_cache)
 
   def record_ts_for_list(self, ls, labels, path, gauge_cache):
-    key = path.pop()
+    new_path, key = path[:-1], path[-1]
     for i, value in enumerate(ls):
       labels = collections.OrderedDict(labels)
       labels[key] = str(i)
-      self.record_ts_for_thing(value, labels, path, gauge_cache)
+      self.record_ts_for_thing(value, labels, new_path, gauge_cache)
 
 
 class PodLabelExporter(object):

--- a/main.py
+++ b/main.py
@@ -78,13 +78,16 @@ class PodLabelExporter(object):
     metric = prometheus_client.core.GaugeMetricFamily("k8s_pod_labels", "Timeseries with the labels for the pod, always 1.0, for joining.")
 
     for pod in pykube.Pod.objects(api).all():
-      unprocessed_labels = safe_lookup(pod.obj, ["metadata", "labels"], {})
-      unprocessed_labels["namespace"] = safe_lookup(pod.obj, ["metadata", "namespace"], "default")
-      unprocessed_labels["pod_name"] = safe_lookup(pod.obj, ["metadata", "name"])
-      labels = {k.replace('-', '_').replace('/', '_').replace('.', '_'): v for k, v in unprocessed_labels.items()}
-      metric.samples.append((metric.name, labels, 1.0))
+      metric.samples.append((metric.name, get_pod_labels(pod), 1.0))
 
     yield metric
+
+
+def get_pod_labels(pod):
+  unprocessed_labels = safe_lookup(pod.obj, ["metadata", "labels"], {})
+  unprocessed_labels["namespace"] = safe_lookup(pod.obj, ["metadata", "namespace"], "default")
+  unprocessed_labels["pod_name"] = safe_lookup(pod.obj, ["metadata", "name"])
+  return {k.replace('-', '_').replace('/', '_').replace('.', '_'): v for k, v in unprocessed_labels.items()}
 
 
 def labels_for(obj):

--- a/main.py
+++ b/main.py
@@ -10,11 +10,11 @@ import pykube, prometheus_client, prometheus_client.core
 class KubernetesAPIExporter(object):
 
   KINDS = {
-    'deployment': pykube.Deployment,
-    'pod': pykube.Pod,
-    'job': pykube.Job,
-    'rc': pykube.ReplicationController,
-    'ds': pykube.DaemonSet,
+    "deployment": pykube.Deployment,
+    "pod": pykube.Pod,
+    "job": pykube.Job,
+    "rc": pykube.ReplicationController,
+    "ds": pykube.DaemonSet,
   }
 
   def __init__(self, api):
@@ -87,33 +87,33 @@ class PodImageExporter(object):
 
 
 def get_pod_labels(pod):
-  metadata = pod.obj.get('metadata', {})
-  unprocessed_labels = metadata.get('labels', {})
+  metadata = pod.obj.get("metadata", {})
+  unprocessed_labels = metadata.get("labels", {})
   unprocessed_labels.update({
-    'namespace': metadata.get('namespace', "default"),
-    'pod_name': metadata.get('name', ""),
+    "namespace": metadata.get("namespace", "default"),
+    "pod_name": metadata.get("name", ""),
   })
-  return {k.replace('-', '_').replace('/', '_').replace('.', '_'): v for k, v in unprocessed_labels.items()}
+  return {k.replace("-", "_").replace("/", "_").replace(".", "_"): v for k, v in unprocessed_labels.items()}
 
 
 def iter_pod_images(pod):
   """Iterate through the images specified for containers in a pod."""
-  metadata = pod.obj.get('metadata', {})
-  containers = pod.obj.get('spec', {}).get('containers', [])
+  metadata = pod.obj.get("metadata", {})
+  containers = pod.obj.get("spec", {}).get("containers", [])
   for container in containers:
     yield {
-      'namespace': metadata.get('namespace', "default"),
-      'pod_name': metadata.get('name', ""),
-      'container_name': container.get('name', ""),
-      'image': container.get('image', ""),
+      "namespace": metadata.get("namespace", "default"),
+      "pod_name": metadata.get("name", ""),
+      "container_name": container.get("name", ""),
+      "image": container.get("image", ""),
     }
 
 
 def labels_for(obj):
-  metadata = obj.get('metadata', {})
+  metadata = obj.get("metadata", {})
   labels = collections.OrderedDict()
-  labels["namespace"] = metadata.get('namespace', "default")
-  labels["name"] = metadata.get('name', "")
+  labels["namespace"] = metadata.get("namespace", "default")
+  labels["name"] = metadata.get("name", "")
   return labels
 
 
@@ -144,5 +144,5 @@ def main():
     time.sleep(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
   main()

--- a/main.py
+++ b/main.py
@@ -3,8 +3,9 @@
 # Kubernetes API Exporter - expose various numbers from the Kubernetes API as
 # Prometheus metrics, such that you can alert on them.
 
-import numbers, string, optparse, time, signal, logging, sys, collections
+import numbers, optparse, time, signal, logging, sys, collections
 import pykube, prometheus_client, prometheus_client.core
+
 
 class KubernetesAPIExporter(object):
 
@@ -15,23 +16,23 @@ class KubernetesAPIExporter(object):
   def collect(self):
     self.gauge_cache = {}
 
-    for deployment in pykube.Deployment.objects(api).all():
+    for deployment in pykube.Deployment.objects(self.api).all():
       labels = labels_for(deployment.obj)
       self.record_ts_for_thing(deployment.obj, labels, ["k8s", "deployment"])
 
-    for pod in pykube.Pod.objects(api).all():
+    for pod in pykube.Pod.objects(self.api).all():
       labels = labels_for(pod.obj)
       self.record_ts_for_thing(pod.obj, labels, ["k8s", "pod"])
 
-    for job in pykube.Job.objects(api).all():
+    for job in pykube.Job.objects(self.api).all():
       labels = labels_for(job.obj)
       self.record_ts_for_thing(job.obj, labels, ["k8s", "job"])
 
-    for pod in pykube.ReplicationController.objects(api).all():
+    for pod in pykube.ReplicationController.objects(self.api).all():
       labels = labels_for(pod.obj)
       self.record_ts_for_thing(pod.obj, labels, ["k8s", "rc"])
 
-    for pod in pykube.DaemonSet.objects(api).all():
+    for pod in pykube.DaemonSet.objects(self.api).all():
       labels = labels_for(pod.obj)
       self.record_ts_for_thing(pod.obj, labels, ["k8s", "ds"])
 
@@ -77,7 +78,7 @@ class PodLabelExporter(object):
   def collect(self):
     metric = prometheus_client.core.GaugeMetricFamily("k8s_pod_labels", "Timeseries with the labels for the pod, always 1.0, for joining.")
 
-    for pod in pykube.Pod.objects(api).all():
+    for pod in pykube.Pod.objects(self.api).all():
       metric.samples.append((metric.name, get_pod_labels(pod), 1.0))
 
     yield metric
@@ -105,7 +106,7 @@ def sigterm_handler(_signo, _stack_frame):
   sys.exit(0)
 
 
-if __name__ == "__main__":
+def main():
   logging.basicConfig(level=logging.INFO)
 
   parser =  optparse.OptionParser("""usage: %prog [options]""")
@@ -125,3 +126,7 @@ if __name__ == "__main__":
   signal.signal(signal.SIGTERM, sigterm_handler)
   while True:
     time.sleep(1)
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
Exports pod image information as kubernetes metrics.

Metrics look like:

```
# HELP k8s_pod_images Timeseries with spec'd images for the pod, always 1.0, for joining.
# TYPE k8s_pod_images gauge
k8s_pod_images{container_name="authfe",image="quay.io/weaveworks/authfe",namespace="default",pod_name="authfe-265929437-8d81v"} 1.0
k8s_pod_images{container_name="logging",image="quay.io/weaveworks/logging",namespace="default",pod_name="authfe-265929437-8d81v"} 1.0
k8s_pod_images{container_name="configs",image="quay.io/weaveworks/configs",namespace="default",pod_name="configs-1703278717-h0d7b"} 1.0
k8s_pod_images{container_name="configs-db",image="postgres:9.6",namespace="default",pod_name="configs-db-4043172166-q3qnm"} 1.0
```

Also has some code cleanup, including:

- don't use globals for passing `api` around
- explicitly pass `gauge_cache`, making the reference lifetime match the actual cache lifetime
- reduce `gauge_cache` scope to be per-kind, since it's impossible for deployments and pods, say, to share metrics
- declare the kinds we export and loop through those, avoiding code duplication
- drop `safe_lookup`, almost all of the time its duplicating work unnecessarily
